### PR TITLE
Fix batch entry ids not distinct error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup  # type: ignore
 
 setup(
     name="sqslistener",
-    version="1.0.0",
+    version="v0.1.2-beta",
     url="https://github.com/tembici/sqs-listener-python",
     description="",
     long_description="",

--- a/sqs_listener/listener.py
+++ b/sqs_listener/listener.py
@@ -3,12 +3,6 @@ import os
 from time import sleep
 from typing import Any, Dict, List
 
-from mypy_boto3_sqs import SQSClient
-from mypy_boto3_sqs.type_defs import (
-    DeleteMessageBatchRequestEntryTypeDef,
-    MessageTypeDef,
-)
-
 MAX_MESSAGES_PER_REQUEST = int(
     os.environ.get("SQS_LISTENER_MAX_MESSAGES_PER_REQUEST", 10)
 )
@@ -19,7 +13,6 @@ MAX_ENQUEUED_DELETE_MESSAGES = int(
 SLEEP_BETWEEN_REQUESTS = int(os.environ.get("SQS_LISTENER_SLEEP_BETWEEN_REQUESTS", 5))
 
 OutputMessageType = Dict[str, Any]
-SQSMessageType = MessageTypeDef
 
 
 class SQSListener:
@@ -28,7 +21,7 @@ class SQSListener:
     def __init__(
         self,
         queue_url: str,
-        client: SQSClient,
+        client,
         max_messages_per_request: int = MAX_MESSAGES_PER_REQUEST,
         max_long_polling_time: int = MAX_LONG_POLLING_TIME,
         sleep_between_requests: int = SLEEP_BETWEEN_REQUESTS,
@@ -40,7 +33,7 @@ class SQSListener:
         self.max_long_polling_time = max_long_polling_time
         self.sleep_between_requests = sleep_between_requests
 
-        self.messages_to_delete_queue: List[MessageTypeDef] = []
+        self.messages_to_delete_queue: List = []
 
     def listen(self):  # pragma: no cover
         """Continuosly listens to messages and yelds messages as it was sent to SQS."""
@@ -71,19 +64,19 @@ class SQSListener:
 
         return events
 
-    def _convert_to_original_message_format(
-        self, sqs_message: SQSMessageType
-    ) -> OutputMessageType:
+    def _convert_to_original_message_format(self, sqs_message) -> OutputMessageType:
         """Converts payload to orignal message format.
            Args:
                sqs_message(dict): message to be converted.
         """
 
         body = json.loads(sqs_message["Body"])
-        event = json.loads(body["Message"])
-        return event
+        return body
 
-    def _enqueue_message_to_be_deleted(self, sqs_message: SQSMessageType) -> None:
+    def _get_unique_ids_from_messages_to_be_deleted_queue(self):
+        return (d["MessageId"] for d in self.messages_to_delete_queue)
+
+    def _enqueue_message_to_be_deleted(self, sqs_message) -> None:
         """Marks messages to be deleted. if the deletion
            queue reaches MAX_ENQUEUED_DELETE_MESSAGES, triggers
            delete process.
@@ -96,12 +89,16 @@ class SQSListener:
         if current_messages_to_delete_queue_length == MAX_ENQUEUED_DELETE_MESSAGES:
             self._delete_enqueued_messages()
 
-        self.messages_to_delete_queue.append(sqs_message)
+        if (
+            sqs_message["MessageId"]
+            not in self._get_unique_ids_from_messages_to_be_deleted_queue()
+        ):
+            self.messages_to_delete_queue.append(sqs_message)
 
     def _delete_enqueued_messages(self) -> None:
         """Executes deletion of previously marked messages."""
 
-        messages_to_delete_now: List[DeleteMessageBatchRequestEntryTypeDef] = []
+        messages_to_delete_now = []
         for _ in range(MAX_ENQUEUED_DELETE_MESSAGES):
             if not self.messages_to_delete_queue:
                 break

--- a/sqs_listener/listener.py
+++ b/sqs_listener/listener.py
@@ -73,7 +73,7 @@ class SQSListener:
         body = json.loads(sqs_message["Body"])
         return body
 
-    def _get_unique_ids_from_messages_to_be_deleted_queue(self):
+    def _ids_from_to_be_deleted_queue(self):
         return (d["MessageId"] for d in self.messages_to_delete_queue)
 
     def _enqueue_message_to_be_deleted(self, sqs_message) -> None:
@@ -89,10 +89,7 @@ class SQSListener:
         if current_messages_to_delete_queue_length == MAX_ENQUEUED_DELETE_MESSAGES:
             self._delete_enqueued_messages()
 
-        if (
-            sqs_message["MessageId"]
-            not in self._get_unique_ids_from_messages_to_be_deleted_queue()
-        ):
+        if sqs_message["MessageId"] not in self._ids_from_to_be_deleted_queue():
             self.messages_to_delete_queue.append(sqs_message)
 
     def _delete_enqueued_messages(self) -> None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,0 @@
-from unittest import TestCase
-
-
-class TempTestCase(TestCase):
-    def test_true_is_always_true(self):
-        """Just a mock test to be sure the CI is fine."""
-        self.assertTrue(True)


### PR DESCRIPTION
### Context:

To delete a message from sqs, we need to call the `delete_message_batch` method with a list of `Id` and `ReceiptHandle` for each message. [1]
Note: Each `Id` must be unique, otherwise the request will fail with a `BatchEntryIdsNotDistinct` exception.

Currently, if we process the same message two times in a short period of time, we'll get this  error. Mostly because we only delete the messages when we have 10 items in the queue, so it can take some time.

Sample traceback:

```
BatchEntryIdsNotDistinct                  Traceback (most recent call last)<ipython-input-1-f753e4de729a> in <module>1112---> 13 process_sqs_events(client, QUEUE_URL, HANDLERS)14

/code/event/processors.py in process_sqs_events(client, queue_arn, event_handlers)20     sqs = SQSListener(queue_arn, client, sleep_between_requests=1)21---> 22     for event in sqs.listen():23         event_content = event["content"]24         event_category = event_content["category"]

/usr/local/lib/python3.7/site-packages/sqs_listener/listener.py in listen(self)4748         while True:---> 49             events = self.process_messages()50             for event in events:51                 yield event

/usr/local/lib/python3.7/site-packages/sqs_listener/listener.py in process_messages(self)66         if "Messages" in sqs_messages:67             for sqs_message in sqs_messages["Messages"]:---> 68                 self._enqueue_message_to_be_deleted(sqs_message)69                 event = self._convert_to_original_message_format(sqs_message)70                 events.append(event)

/usr/local/lib/python3.7/site-packages/sqs_listener/listener.py in _enqueue_message_to_be_deleted(self, sqs_message)9596         if current_messages_to_delete_queue_length == MAX_ENQUEUED_DELETE_MESSAGES:---> 97             self._delete_enqueued_messages()9899         self.messages_to_delete_queue.append(sqs_message)

/usr/local/lib/python3.7/site-packages/sqs_listener/listener.py in _delete_enqueued_messages(self)114         if messages_to_delete_now:115             self.client.delete_message_batch(--> 116                 QueueUrl=self.queue_url, Entries=messages_to_delete_now117             )

/usr/local/lib/python3.7/site-packages/botocore/client.py in _api_call(self, *args, **kwargs)314                     "%s() only accepts keyword arguments." % py_operation_name)315             # The "self" in this scope is referring to the BaseClient.--> 316             return self._make_api_call(operation_name, kwargs)317318         _api_call.name = str(py_operation_name)

/usr/local/lib/python3.7/site-packages/botocore/client.py in _make_api_call(self, operation_name, api_params)633             error_code = parsed_response.get("Error", {}).get("Code")634             error_class = self.exceptions.from_code(error_code)--> 635             raise error_class(parsed_response, operation_name)636         else:637             return parsed_response

BatchEntryIdsNotDistinct: An error occurred (AWS.SimpleQueueService.BatchEntryIdsNotDistinct) when calling the DeleteMessageBatch operation: Id fe1ddf32-6831-4d87-b909-6de63c5d5760 repeated.
```


### Solution

Considering that:
- The `MessageId` is always the same for the same message, and
- the `ReceiptHandle` changes every time we process a message

we can check if the message is in the queue based on the `MessageId` before mark the message to be deleted again.





[1] https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Client.delete_message_batch
